### PR TITLE
[squid:S1858] "toString()" should never be called on a String object

### DIFF
--- a/app/src/main/java/com/shapps/mintubeapp/MainActivity.java
+++ b/app/src/main/java/com/shapps/mintubeapp/MainActivity.java
@@ -151,7 +151,7 @@ public class MainActivity extends AppCompatActivity implements SearchView.OnQuer
                         Pattern pattern = Pattern.compile(
                                 "([A-Za-z0-9_-]+)&[\\w]+=.*",
                                 Pattern.CASE_INSENSITIVE);
-                        Matcher matcher = pattern.matcher(listID.toString());
+                        Matcher matcher = pattern.matcher(listID);
                         Log.d("ListID", listID);
                         PID = "";
                         if (matcher.matches()) {

--- a/app/src/main/java/com/shapps/mintubeapp/YTubeView.java
+++ b/app/src/main/java/com/shapps/mintubeapp/YTubeView.java
@@ -81,12 +81,12 @@ public class YTubeView extends Activity{//extends YouTubeFailureRecoveryActivity
             } else {
                 link = intent.getStringExtra("android.intent.extra.TEXT");
             }
-            Log.d("Link : ", link.toString());
+            Log.d("Link : ", link);
             vId = "";
             Pattern pattern = Pattern.compile(
                     "^https?://.*(?:youtu.be/|v/|u/\\\\w/|embed/|watch[?]v=)([^#&?]*).*$",
                     Pattern.CASE_INSENSITIVE);
-            Matcher matcher = pattern.matcher(link.toString());
+            Matcher matcher = pattern.matcher(link);
             if (matcher.matches()) {
                 vId = matcher.group(1);
             }
@@ -98,7 +98,7 @@ public class YTubeView extends Activity{//extends YouTubeFailureRecoveryActivity
             String regex = ".*list=([A-Za-z0-9_-]+).*?";
             pattern = Pattern.compile(regex,
                     Pattern.CASE_INSENSITIVE);
-            matcher = pattern.matcher(link.toString());
+            matcher = pattern.matcher(link);
             if (matcher.matches()) {
                 pId = matcher.group(1);
                 Log.d("PID Is : ", pId);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1858 - “"toString()" should never be called on a String object”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1858

Please let me know if you have any questions.
Ayman Abdelghany.
